### PR TITLE
Update ScalaTest version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,4 +4,4 @@ ThisBuild / scalaVersion := "2.13.12"
 
 name := "dutch-stemmer"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % Test
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % Test

--- a/src/test/scala/com/log4p/DutchStemmerTestSuite.scala
+++ b/src/test/scala/com/log4p/DutchStemmerTestSuite.scala
@@ -1,9 +1,9 @@
 package com.log4p
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import scala.xml._
 
-class DutchStemmerTestSuite extends FunSuite {
+class DutchStemmerTestSuite extends AnyFunSuite {
   test("R1 should be the part after the first non-vowel after a vowel") {
     assert(Payload("sinterklaas").R1 === "terklaas")
   }


### PR DESCRIPTION
## Summary
- update ScalaTest to 3.2.18
- switch tests to `AnyFunSuite` style

## Testing
- `sbt test` *(fails: `sbt: command not found`)*