### PR TITLE
Upgrade to Scala 3

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -8,7 +8,7 @@ My aim was to make a stateless implementation which passes the tests to learn ho
 h2. Prerequisites
 
 * sbt 1.9.x
-* Scala 2.13.x
+* Scala 3.x
 
 h2. Usage
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 ThisBuild / organization := "dutch_stemmer"
 ThisBuild / version := "1.0.0"
-ThisBuild / scalaVersion := "2.13.12"
+ThisBuild / scalaVersion := "3.4.1"
 
 name := "dutch-stemmer"
 

--- a/src/main/scala/com/log4p/DutchStemmer.scala
+++ b/src/main/scala/com/log4p/DutchStemmer.scala
@@ -1,6 +1,7 @@
 package com.log4p
 
 import scala.util.matching.Regex.Match
+import scala.language.implicitConversions
 
 /**
  * Implementation of a stemming algorithm for the Dutch language.


### PR DESCRIPTION
## Summary
- upgrade Scala to 3.4.1
- update README for Scala 3
- add `scala.language.implicitConversions` import for Scala 3

## Testing
- `sbt test` *(fails: `sbt: command not found`)*