### PR TITLE
Fix infix warning in DutchStemmer

### DIFF
--- a/src/main/scala/com/log4p/DutchStemmer.scala
+++ b/src/main/scala/com/log4p/DutchStemmer.scala
@@ -34,7 +34,7 @@ object DutchStemmer {
                 step3b(_:Payload),
                 step4(_:Payload),
                 {(p: Payload) => Payload(p.word.toLowerCase, "lowercased" :: p.history)}
-        ) exec input
+        ).exec(input)
   }
   
   /** removes one character from the end of the string if the end matches kk, dd or tt */ 


### PR DESCRIPTION
## Summary
- call `exec` with dot notation to avoid infix warning

## Testing
- `sbt test` *(fails: `sbt` not found)*