### PR TITLE
Improve scala idioms

### DIFF
--- a/src/main/scala/com/log4p/Accents.scala
+++ b/src/main/scala/com/log4p/Accents.scala
@@ -1,9 +1,9 @@
 package com.log4p
 
 object Accents {
-	
-  /** remaps all accented vowel in the input string to the specified counterparts */	
-  def transpostAccents(s:String):String = s.toCharArray.map(transposeAccent(_)).mkString
+
+  /** remaps all accented vowel in the input string to the specified counterparts */
+  def transposeAccents(s:String):String = s.toCharArray.map(transposeAccent(_)).mkString
 	
   def transposeAccent(c:Char):Char = {
     c match {

--- a/src/test/scala/com/log4p/DutchStemmerTestSuite.scala
+++ b/src/test/scala/com/log4p/DutchStemmerTestSuite.scala
@@ -36,14 +36,12 @@ class DutchStemmerTestSuite extends AnyFunSuite {
   test("verify supplied vocabulary") {
     val doc = XML.loadFile("src/test/resources/test_input.xml")
     val tests = (doc \ "test")
-    var count = 0
-    tests.foreach { ele =>
+    tests.zipWithIndex.foreach { case (ele, count) =>
       val input = ele.attribute("input").get.toString
       val output = ele.attribute("output").get.toString
       val stem = DutchStemmer.stem(input)
-  
+
       assert(stem.word === output, "failed stemming[%s->%s] at: %d %s".format(input, output, count, stem))
-      count = count + 1
     }
   }
 }


### PR DESCRIPTION
## Summary
- rename `transpostAccents` to `transposeAccents`
- remove implicit conversion in `DutchStemmer`
- rewrite `step1` without explicit returns
- use `zipWithIndex` in vocabulary test

## Testing
- `sbt test` *(fails: sbt not installed)*